### PR TITLE
Run the script from the root project dir

### DIFF
--- a/lib/twine/runner.rb
+++ b/lib/twine/runner.rb
@@ -188,7 +188,7 @@ module Twine
       end
 
       Dir.glob(File.join(@options[:input_path], "**/*")) do |item|
-        if File.file?(item)
+        if File.file?(item) && item =~ /\/values(?:-[a-z]{2})?\/.*\.xml$/ && item !~ %r{\/build\/}
           begin
             read_localization_file(item)
           rescue Twine::Error => e
@@ -319,6 +319,8 @@ module Twine
     end
 
     def read_localization_file(path, lang = nil)
+      Twine::stdout.puts "+++++++++++++++++++++++++++"
+      Twine::stdout.puts path
       unless File.file?(path)
         raise Twine::Error.new("File does not exist: #{path}")
       end


### PR DESCRIPTION
```
Before we had to run the script from each module:
bundle exec bin/twine consume-all-localization-files ../mobile-next-gen-android/PaylocityNG/twine_output.txt ../mobile-next-gen-android/PaylocityNG/recognition-and-rewards -a -c -f android

After we will be able to run the script for all the modules at once:
bundle exec bin/twine consume-all-localization-files ../mobile-next-gen-android/PaylocityNG/twine_output.txt ../mobile-next-gen-android/PaylocityNG -a -c -f android
```